### PR TITLE
Add support for color parameter

### DIFF
--- a/jekyll-geo-pattern.gemspec
+++ b/jekyll-geo-pattern.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.files                 = ["lib/jekyll-geo-pattern.rb"]
 
   s.add_dependency "jekyll"
-  s.add_dependency "geo_pattern", "~> 1.1.2"
+  s.add_dependency "geo_pattern", "~> 1.2.1"
   s.add_development_dependency "rspec", "~> 2.13.0"
   s.add_development_dependency "rake"
 end

--- a/lib/jekyll-geo-pattern.rb
+++ b/lib/jekyll-geo-pattern.rb
@@ -2,7 +2,7 @@ require 'geo_pattern'
 
 module Jekyll
   module GeoPatterns
-    VALID_KEYS = %w(:base_color :generator :text)
+    VALID_KEYS = %w(:base_color :color :generator :text)
     VALID_SYNTAX = /([\w-]+)\s*=\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))/
 
     # from a string of options, construct a hash, without using `eval`


### PR DESCRIPTION
This adds support for the `color` parameter added in `v1.2.0` of the geo_pattern library. I went ahead and bumped the `gemspec` to `v1.2.1` since it fixes the fact that I had 17 available patterns when I swore I had 16. :unamused:
